### PR TITLE
Add ComputedOption to update config at command runtime

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -9,6 +9,9 @@ import (
 
 type Option func(*Config)
 
+// ComputedOption are applied just before running the request.
+type ComputedOption func(*Config) error
+
 func WithServerAddr(addr string) Option {
 	return func(c *Config) {
 		c.ServerAddr = addr
@@ -111,5 +114,12 @@ func WithOutputEncoder(format string, maker iocodec.EncoderMaker) Option {
 		}
 		e[format] = maker
 		c.outEncoders = e
+	}
+}
+
+// WithComputedOption registers options that are applied just before running the request.
+func WithComputedOption(opt ComputedOption) Option {
+	return func(c *Config) {
+		c.computedOpts = append(c.computedOpts, opt)
 	}
 }

--- a/cobra.go
+++ b/cobra.go
@@ -112,7 +112,7 @@ func _{{.Parent.GoName}}{{.GoName}}Command(cfg *client.Config) *cobra.Command {
 			}
 			return client.RoundTrip(cmd.Context(), cfg, func(cc grpc.ClientConnInterface, in iocodec.Decoder, out iocodec.Encoder) error {
 				cli := New{{.Parent.GoName}}Client(cc)
-				v := &{{.Input.GoIdent.GoName}}{}
+				v := &{{ qualifiedGoIdent .Input.GoIdent}}{}
 	{{if .Desc.IsStreamingClient}}
 				stm, err := cli.{{.GoName}}(cmd.Context())
 				if err != nil {
@@ -177,9 +177,7 @@ func _{{.Parent.GoName}}{{.GoName}}Command(cfg *client.Config) *cobra.Command {
 	return cmd
 }
 `
-	methodTemplate = template.Must(template.New("method").
-			Funcs(template.FuncMap{"cleanComments": cleanComments}).
-			Parse(methodTemplateCode))
+
 	methodImports = []protogen.GoImportPath{
 		"github.com/golang/protobuf/proto",
 		"github.com/NathanBaulch/protoc-gen-cobra/client",
@@ -191,6 +189,14 @@ func _{{.Parent.GoName}}{{.GoName}}Command(cfg *client.Config) *cobra.Command {
 )
 
 func genMethod(g *protogen.GeneratedFile, method *protogen.Method, enums map[string]*enum) error {
+	methodTemplate := template.Must(template.New("method").
+		Funcs(template.FuncMap{
+			"cleanComments": cleanComments,
+			"qualifiedGoIdent": func(i protogen.GoIdent) string {
+				return g.QualifiedGoIdent(i)
+			}}).
+		Parse(methodTemplateCode))
+
 	for _, imp := range methodImports {
 		g.QualifiedGoIdent(protogen.GoIdent{GoImportPath: imp})
 	}

--- a/iocodec/iocodec.go
+++ b/iocodec/iocodec.go
@@ -34,7 +34,9 @@ func JSONDecoderMaker() DecoderMaker {
 }
 
 func JSONEncoderMaker(pretty bool) EncoderMaker {
-	m := &jsonpb.Marshaler{}
+	m := &jsonpb.Marshaler{
+		EmitDefaults: true,
+	}
 	if pretty {
 		m.Indent = "  "
 	}


### PR DESCRIPTION
Hi :)

I added the`WithComputedOption` to update configuration just before running the gRPC request.
It allows to use external configuration flags. 

On a CLI managing multiple environments it's easier to set `--env=prod` than `--server-addr=my-prod.endpoint:
8080`. But using `--env=prod` the command needs to do more computation, and at runtime. That's why I added this feature.

I hope you'll find it useful :) 