### PR TITLE
enable passing client conn

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -27,7 +27,7 @@ type (
 )
 
 type Config struct {
-	ClientConn grpc.ClientConnInterface
+	ClientConnFunc func() grpc.ClientConnInterface
 
 	ServerAddr     string
 	RequestFile    string
@@ -111,7 +111,7 @@ func RegisterOutputEncoder(format string, maker iocodec.EncoderMaker) {
 }
 
 func (c *Config) BindFlags(fs *pflag.FlagSet) {
-	if c.ClientConn == nil {
+	if c.ClientConnFunc == nil {
 		fs.StringVarP(&c.ServerAddr, c.FlagNamer("ServerAddr"), "s", c.ServerAddr, "server address in the form host:port")
 		fs.DurationVar(&c.Timeout, c.FlagNamer("Timeout"), c.Timeout, "client connection timeout")
 		fs.BoolVar(&c.TLS, c.FlagNamer("TLS"), c.TLS, "enable TLS")
@@ -164,8 +164,8 @@ func RoundTrip(ctx context.Context, cfg *Config, fn func(grpc.ClientConnInterfac
 		return err
 	}
 
-	if cfg.ClientConn != nil {
-		return fn(cfg.ClientConn, in, out)
+	if cfg.ClientConnFunc != nil {
+		return fn(cfg.ClientConnFunc(), in, out)
 	}
 
 	opts := []grpc.DialOption{grpc.WithBlock()}

--- a/client/options.go
+++ b/client/options.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/NathanBaulch/protoc-gen-cobra/iocodec"
 	"github.com/NathanBaulch/protoc-gen-cobra/naming"
+	"google.golang.org/grpc"
 )
 
 type Option func(*Config)
@@ -100,6 +101,12 @@ func WithInputDecoder(format string, maker iocodec.DecoderMaker) Option {
 		}
 		d[format] = maker
 		c.inDecoders = d
+	}
+}
+
+func WithClientConn(cc grpc.ClientConnInterface) Option {
+	return func(c *Config) {
+		c.ClientConn = cc
 	}
 }
 

--- a/client/options.go
+++ b/client/options.go
@@ -104,9 +104,9 @@ func WithInputDecoder(format string, maker iocodec.DecoderMaker) Option {
 	}
 }
 
-func WithClientConn(cc grpc.ClientConnInterface) Option {
+func WithClientConnFunc(f func() grpc.ClientConnInterface) Option {
 	return func(c *Config) {
-		c.ClientConn = cc
+		c.ClientConnFunc = f
 	}
 }
 


### PR DESCRIPTION
This would enable passing an already existing `grpc.ClientConnInterface` to the configuration. It is passed using a func as in some cases, i.e. auto completion it is not needed.

I'd need that feature for my use case. Perhaps it might be interesting for others too.

<sub>Mathias Zeller <mathias.zeller@mercedes-benz.com> Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))
</sub>