### PR TITLE
Fix code generation when the request message isn't defined in the same package

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -95,7 +95,7 @@ func _{{.Parent.GoName}}{{.GoName}}Command(cfg *client.Config) *cobra.Command {
 			}
 			return client.RoundTrip(cmd.Context(), cfg, func(cc grpc.ClientConnInterface, in iocodec.Decoder, out iocodec.Encoder) error {
 				cli := New{{.Parent.GoName}}Client(cc)
-				v := &{{.Input.GoIdent.GoName}}{}
+				v := &{{.InputType}}{}
 	{{if .Desc.IsStreamingClient}}
 				stm, err := cli.{{.GoName}}(cmd.Context())
 				if err != nil {


### PR DESCRIPTION
Hello :wave: 

When a message is defined in a package that's different from when the service is defined, the message needs to have its package name explicited. Hopefully, line 80 was declaring it correctly, so I fixed the declaration line 98 with the same variable.

Have a nice day! :)